### PR TITLE
docs: Corrections I've noticed since writing

### DIFF
--- a/episodes/branching.md
+++ b/episodes/branching.md
@@ -470,7 +470,7 @@ git reset --soft HEAD~1
 
 ## Challenge 6: Commits on the wrong branch
 
-- Checkout the `main` branch.
+- Checkout the `main` branch of the `pytest-example` repository.
 - Create a new file using `echo "# How to Contribute to this repo" > CONTRIBUTING.md`
 - Stage and commit the file to the `main` branch of your repository.
 
@@ -485,17 +485,18 @@ to a new branch so you can push them.
 
 ## Solution
 
-You can use the `-d` or `--delete` flag to delete a branch.
+You can reset the HEAD to the previous commit, which removes the `CONTRIBUTING.md` file from the commit history, leaving
+it unstaged, then create a new branch and add it to that.
 
 ``` bash
 git switch main
 echo "# How to Contribute to this repo" > CONTRIBUTING.md
 git add CONTRIBUTING.md
-git commit -m "Adding contributing guideline template"
+git commit -m "docs: Adding contributing guideline template"
 git reset --hard HEAD~1
 git switch -c ns-rse/contributing
 git add CONTRIBUTING.md
-git commit -m "Adding contributing guideline template"
+git commit -m "docs: Adding contributing guideline template"
 ```
 
 :::::::::::::::::::::::::::::::::
@@ -504,17 +505,21 @@ git commit -m "Adding contributing guideline template"
 
 ## Solution
 
-Alternatively you can checkout the previous commit _before_ you added the file by mistake, create the `<github_user>/contributing`
-branch,  and `git cherrypick` the commit from `main` which contains the `CONTRIBUTING.md` file and _then_ remove the
-commit from main.
+Alternatively you can checkout the previous commit _before_ you added the file by mistake, create the
+`<github_user>/contributing` branch,  and `git cherrypick` the commit from `main` which contains the `CONTRIBUTING.md`
+file and _then_ remove the commit from main.
 
 ``` bash
-# TODO get commit hash of last commit
-git checkout HEAD~1
+git switch main
+echo "# How to Contribute to this repo" > CONTRIBUTING.md
+git add CONTRIBUTING.md
+git commit -m "docs: Adding contributing guideline template"
+git log              # Note the commit of the mistaken hash
+git revert HEAD~1   # Checkout the previous commit on the main branch
 git switch -c ns-rse/contributing
 git cherrypick <hash>
-git
-# TODO : Complete solution and add output once sample repository is in place
+git switch main
+git reset --hard HEAD~1
 ```
 
 :::::::::::::::::::::::::::::::::
@@ -539,7 +544,7 @@ git
 # TODO : Complete solution and add output once sample repository is in place
 ```
 
-**NB** You could also copy the file using the older `git checkoug main -- CONTRIBUTING.md`.
+**NB** You could also copy the file using the older `git checkout main -- CONTRIBUTING.md`.
 
 :::::::::::::::::::::::::::::::::
 ::::::::::::::::::::::::::::::::::::::::::::::::
@@ -706,7 +711,7 @@ git commit --allow-empty -m "Initial commit"
 git switch -c branch1
 echo "# Just a test" > README.md
 git add README.md
-git commit -m "Adding README.md"
+git commit -m "docs: Adding README.md"
 ```
 
 #### 3. Switch back to `main`
@@ -890,7 +895,7 @@ git commit --allow-empty -m "Initial commit"
 git switch -c branch1
 echo "# Just a test" > README.md
 git add README.md
-git commit -m "Adding README.md"
+git commit -m "docs: Adding README.md"
 ```
 
 #### 3. Switch back to `main`
@@ -908,7 +913,7 @@ cat README.md   # Note that `README.md` does not currently exist on this branch
 git switch -c branch2
 echo "THIS IS A LICENSE" > LICENSE
 git add LICENSE
-git commit -m "Adding a LICENSE"
+git commit -m "docs: Adding a LICENSE"
 ```
 
 #### 5. Merge `branch1` into `main` (equivalent to making a Pull Request)
@@ -949,8 +954,8 @@ git switch main
 git merge branch2
 glod
 
-* 12f5202 - (HEAD -> main, branch2) Adding a LICENSE (2024-03-01 12:19:12 +0000) <Neil Shephard>
-* 4e8e933 - (branch1) Adding README.md (2024-03-01 12:18:37 +0000) <Neil Shephard>
+* 12f5202 - (HEAD -> main, branch2) docs: Adding a LICENSE (2024-03-01 12:19:12 +0000) <Neil Shephard>
+* 4e8e933 - (branch1) docs: Adding README.md (2024-03-01 12:18:37 +0000) <Neil Shephard>
 * 2459609 - Initial commit (2024-03-01 12:18:37 +0000) <Neil Shephard>
 ```
 
@@ -1054,10 +1059,10 @@ Again we add a `README.md` but this time we make two commits to it, adding an ex
 git switch -c branch1
 echo "# Just a test\n" > README.md
 git add README.md
-git commit -m "Adding README.md"
+git commit -m "docs: Adding README.md"
 echo "\nLets add another line in a separate commit" >> README.md
 git add README.md
-git commit -m "Ooops, missed a line from the README.md"
+git commit -m "docs: Ooops, missed a line from the README.md"
 ```
 
 #### 3. Switch back to `main`
@@ -1486,8 +1491,8 @@ will be over-written if they differ from those on the branch you are switching t
 This means either making a commit or stashing the work to come back to at a later date. Neither of these are
 particularly problematic as you can `git pop` stashed work to restore it or or `git commit --amend`, or `git commit
 --fixup` and squash commits to maintain small atomic commits and avoid cluttering up the commit history with commits
-such as "_Saving work to review another branch_". But, perhaps unsurprisingly, Git has another way of helping your
-workflow in this situation. Rather than having branches you can use "_worktrees_".
+such as "_Saving work to review another branch_" (more on this in the next episode!). But, perhaps unsurprisingly, Git
+has another way of helping your workflow in this situation. Rather than having branches you can use "_worktrees_".
 
 Normally when you've `git clone`'d a repository all configuration files for working with the repository are saved to the
 repository directory under `.git` _and_ all files in their current state on the `main` branch are also copied to the
@@ -1583,6 +1588,8 @@ git stash -m "An example stash"
 git switch main
 git switch -c citation
 echo "cff-version: 1.2.0\ntitle: Pytest Examples\ntype: software" > CITATION.cff
+git add CITATION.cff
+git commit -m "chore: Adding a CITATION.cff"
 ```
 
 When we are ready to return to our `contributing` branch we can switch and `git pop` the work we stashed. By default the
@@ -1594,7 +1601,9 @@ git switch contributing
 git pop
 ```
 
-## Worktrees rather than branches
+This works but its quite a few steps to make stashes and "pop" them once we've finished on the other br
+
+### The Worktree
 
 Worktrees take a different approach to organising branches. They start with a `--bare` clone of the repository which
 implies the `--no-checkout` flag and means that the files that would normally be found under the `<repository>/.git`

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -7,15 +7,15 @@ title: Setup
 There are many Git clients (porcelains) out there and many Integrated Development Environments (IDEs) support Git
 actions and facilitate using the bewildering array of options, but this course teaches the Command Line Interface (CLI)
 to Git as it means we have a consistent interface to teach the _principles_ that you can take away to your own choice of
-Git client. Below there are instructions for installing Git on each of the three most common operating systems as well
-as links to download the Git tool GitKraken which includes Git and a Terminal.
+Git client. Below there are instructions for installing Git on each of the three most common operating systems.
 
 Please complete these setup tasks _before_ attending the course. If you have any issues getting setup please either
 contact an instructor in advance or arrive early and seek assistance from an instructor.
 
 ## Example Repository
 
-This course uses a GitHub Template that you will, in small groups, create a copy of and collaborate on.
+This course uses a GitHub Template that you will, in small groups, create a copy of and collaborate on. Using this
+template and setting it up is part of the course, you do not need to set it up in advance.
 
 ## Software Setup
 
@@ -26,10 +26,9 @@ Git the chances are you already have it installed or it may be integrated into y
 (IDE).
 
 For consistency across operating systems this course uses the Command Line Interface (CLI) to Git and instructions below
-will guide you through installation on different Operating Systems.
-
-An alternative option is provided using the [GitKraken][gitkraken] client as many of those attending the course may
-already be using this software, but the Command Line Interface (Terminal) of that client will be used.
+will guide you through installation on different Operating Systems. The principles can be applied to any Git Porcelain
+(client) that you choose, including IDEs, although not all will support all of the functions introduced here (e.g. the
+RStudio Git interface is very basic).
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -102,17 +101,6 @@ emerge -av dev-vcs/git
 
 :::::::::::::::::::::::::
 
-:::::::::::::::: solution
-
-### GitKraken
-
-[GitKraken][gitkraken] is a GUI porcelain for using Git, but it comes bundled with its own version of [Git][git]. Whilst
-it is not open source it uses a Freemium model and the free version contains all of the functionality required for this
-course. It is available across all three of the mentioned platforms and once installed you can start a Terminal by
-clicking on the [Terminal button](https://help.gitkraken.com/gitkraken-client/terminal/) in the toolbar.
-
-:::::::::::::::::::::::::
-
 ## GitHub
 
 ::::::::::::::::::::::::::::::::::::::: discussion
@@ -121,27 +109,48 @@ You will also need an account on [GitHub][gh]. If you do not already have one pl
 [register](https://github.com/signup), if you have an academic email address such as `@<institute>.ac.uk` or
 `@<institute.edu` then registering with this address will give you access to a few more features.
 
-You should generate an SSH key and add the public component to your GitHub account.
+You should generate an SSH keys _and use a secure password when creating them_, then add the public component to your
+GitHub account.
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::
-
-**TODO** Link to instructions on generating keys under different OSs.
 
 :::::::::::::::: solution
 
 ### Windows
 
-:::::::::::::::::::::::::
-
-:::::::::::::::: solution
-
-### OSX
+There are [comprehensive instructions][putty-ssh] on using the Windows SSH client [PuTTY][putty] to generate SSH keys.
 
 :::::::::::::::::::::::::
 
 :::::::::::::::: solution
 
-### Linux
+### Linux / OSX
+
+There is a detailed [article][ssh-keygen] on creating SSH keys under Linux and OSX. It is recommended to use the newer
+[ed25519][ssh-ed25519] algorithm. In a terminal you can do this using the following commands.
+
+``` bash
+ssh-keygen -a 100 -t ed25519
+```
+
+This creates two files in the `~/.ssh/` directory the private key (`~/.ssh/id_ed25519'`) and the public key
+(`~/.ssh/id_ed25519.pub`). These are text files and it is the contents of the later that you need to add to GitHub (see
+next solution). You can view the contents of the `~/.ssh/id_ed25519.pub` file that you need to copy to your GitHub
+account with.
+
+``` bash
+cat ~/.ssh/id_ed25519.pub
+```
+
+:::::::::::::::::::::::::
+
+:::::::::::::::: solution
+
+### Adding Keys to GitHub (All OSs)
+
+Once you have created your SSH key you need to copy it to your account, got to _Settings > SSh and GPG Keys_ and click
+on the _New SSH key_ button. Enter a name for your key, set the **Key type** to _Authenticaion Key_ and paste your
+public key (the contents of the file ending in `.pub`) into the **Key** box then click the _Add SSH key_ button.
 
 :::::::::::::::::::::::::
 
@@ -189,9 +198,12 @@ conda install pip
 
 [gh]: https://github.com
 [git]: https://git-scm.com/
-[gitkraken]: https://www.gitkraken.com/
 [gitMac]: https://git-scm.com/download/mac
 [gitWin]: https://git-scm.com/download/win
 [git4windows]: https://carpentries.github.io/workshop-template/install_instructions/#shell
 [miniconda3]: https://docs.anaconda.com/free/miniconda/
+[putty]: https://www.ssh.com/ssh/putty/download
+[putty-ssh]: https://www.ssh.com/academy/ssh/putty/windows/puttygen#creating-a-new-key-pair-for-authentication
 [python]: https://python.org
+[ssh-ed25519]: https://blog.g3rt.nl/upgrade-your-ssh-keys.html
+[ssh-keygen]: https://www.digitalocean.com/community/tutorials/how-to-create-ssh-keys-with-openssh-on-macos-or-linux


### PR DESCRIPTION
+ Removes reference to GitKraken, it doesn't seem to include a CLI version of `git`.
+ Removes duplicate heading from branching.py (for Worktrees section)
+ Adds conventional commit syntax to many of the commits on `branching.md`.

May need to revise some of the output under `git_hygeine.md` so that the commits match before/after using `!fixup` or `squash`.