### PR TITLE
feature: Embedded mermaid diagrams

### DIFF
--- a/episodes/branching.md
+++ b/episodes/branching.md
@@ -31,14 +31,14 @@ update the code base, but what is a branch?
 The word suggests an analogy with trees where branches are parts of a tree that extend from the "main" trunk or recursively
 from parent "branches". An intuitive model of this is shown in the figure below.
 
-<!-- Source for Mermaid diagram :
-     https://gist.github.com/ns-rse/08fb86b003a26f7855281eeea88566d0#file-git_graph_branching_branches-js
--->
-<!--
+``` mermaid
 %%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
          }
 }%%
     gitGraph
+       accTitle: Simple Git Branches
+       accDescr {Basic GitHub Branches with the main branch showing five commits and a branch forking off at the
+       third commit with two commits of its own.}
        commit id: "0-472f101"
        commit id: "1-51816d6"
        commit id: "2-6769ff2 (base)"
@@ -50,10 +50,8 @@ from parent "branches". An intuitive model of this is shown in the figure below.
        commit id: "5-2315fa0 (HEAD)"
        checkout main
        commit id: "6-93e787c (HEAD)"
--->
 
-<!-- markdownlint-disable-next-line MD013 -->
-![Basic GitHub Branches](https://mermaid.ink/img/pako:eNqVkTtrwzAUhf-KuWDcgh30sPVa29KlW7fiRZHkWKS2gitDU-P_XjshJUNKqab7-M65gjOBCdaBgjSdfO-jSqYstq5zmUqyrf5wWZ5kOx-fB31os3U7hKijewhd5-OL3rr3ZRqH0c11n1zeUs9peh5cxD9rc5Im3qqkBlSUnDQY4RpuA7iosMDMst8AUjDOZNOQ5G797_0Vtx10b9qFORe_OdBCmIpY466B1pl9GGPSad_flpWFcIYKqW_J_rpZFYTiqtHofzdZIanjgpsaIIfODQtql_SmFa_hlFwNK2n1sF-954UbD3aJ7Mn6GAZQa1g56DGG12NvLv2ZefR6N-juMjzo_i2E6xbUBJ-gWLXBkmAqCUKIlLLM4QiKSLmhAqFKcsIk54LOOXydDPCmZJRhxEqJkRCC8fkbTTe3dw?type=png){alt="Basic GitHub Branches with the `main` branch showing five commits and a `branch` forking off at the third commit with two commits of its own"}
+```
 
 The `branch` has two commits on it and stems from the parent `main` at a point referred to as `base`. A branch is _not_
 just the two commits that appear to exist on it (i.e. `3-8c52dce` and `5-2315fa0`) rather it is the full commit history
@@ -463,14 +461,13 @@ Git has kept track of everything you can do that and the command to do so is `gi
 an argument. So far you have been using branch names as references but commit hashes are also references and so can be
 used to checkout the state of the repository in the past.
 
-<!-- Source for Mermaid diagram :
-     https://gist.github.com/ns-rse/08fb86b003a26f7855281eeea88566d0#file-git_graph_branching_diverging_checkout-js
--->
-<!--
+``` mermaid
 %%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
          }
 }%%
     gitGraph
+       accTitle: Simple Git Branches
+       accDescr {A linear Git History on the main branch showing the position of HEAD.}
        commit id: "0-472f101"
        commit id: "1-51816d6"
        commit id: "2-6769ff2"
@@ -481,10 +478,7 @@ used to checkout the state of the repository in the past.
        commit id: "7-bc43901"
        commit id: "8-a80cef8" tag: "HEAD"
 
--->
-
-<!-- markdownlint-disable-next-line MD013 -->
-![A linear Git History on the `main` branch showing the position of `HEAD`.](https://mermaid.ink/img/pako:eNp1kT1rwzAQhv-KOTBerCDJ1oe1lSa0Q7duxYsiyYlobAdHgabG_71ygguFWpPuuecOjncE01sHCtJ09J0PKhmzcHSty1SS7fXFZXmSHXx4GfT5mM3doQ86uOe-bX1403t3ijQMVzfVXbK8-J_S9AGW4d-2uY8m3qqkBoxKQRuCSQ3_CwQxIgm3fE2giAteNQ1dEwokDaPWuDWhRNKZQlZ6TWCIFoQ1Gq8JHFWFE1KYNUGgvSmLav1MibTExjWyhiTow4xed0_bRYccWje02tsY1TizGu4x1TCrVg-fszpF73q2MZ-d9aEfQM3J5KCvoX-_dWapH87W68OgW1CNPl0iPevuo-__1KBG-AJFRblhFDMuZSk445TlcItYlhuBaYEJpixex6ccvu8b8EYyIbGsGClwbFA6_QAk7q7t?type=png){alt="A linear Git History on the `main` branch showing the position of `HEAD`."}
+```
 
 Here we have a simple linear history and the `HEAD` of branch is on commit `8-a80cef8` If you want to checkout commit
 `4-8ec389a` then you would `git checkout 4-8ec389a` and you will see the following useful and informative warning
@@ -660,14 +654,13 @@ Normally you are working on the `HEAD` of a branch which is the most recent comm
 staged, but uncommitted changes. Git has a simple way of referring to previous commits relative to `HEAD` using the `~`
 (tilde) character and counting backwards.
 
-<!-- Source for Mermaid diagram :
-     https://gist.github.com/ns-rse/08fb86b003a26f7855281eeea88566d0#file-git_graph_branching_relative_refs-js
--->
-<!--
+``` mermaid
 %%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
          }
 }%%
     gitGraph
+       accTitle: Simple Git Branches
+       accDescr {Relative references on the main branch with 9 commits showing the commit hash and the reference relative to the HEAD.}
        commit id: "0-472f101" tag: "~8"
        commit id: "1-51816d6" tag: "~7"
        commit id: "2-6769ff2" tag: "~6"
@@ -678,9 +671,7 @@ staged, but uncommitted changes. Git has a simple way of referring to previous c
        commit id: "7-bc43901" tag: "~1"
        commit id: "8-a80cef8" tag: "HEAD"
 
--->
-<!-- markdownlint-disable-next-line MD013 -->
-![Relative Refs on a Git Branch](https://mermaid.ink/img/pako:eNp10k1rgzAYB_CvIg8UL6bkxbzobaxlO-y22_CSxtiGVS02hXXiPvtii5uDmVPyf34JJE96MG1pIYfVqneN83nUx_5gaxvnUbzTZxsnUbx3_qnTp0M8VrvWa28f27p2_kXv7DGkvrvYoWiiaYT5sFrdg2nzT9nctkauzKMCMEolrQgmBURe78foSxXwPyaIE0VEKWZYLmGKhBRZVdEZFkuYIWU4LY2dYb6EU6SsYSrTM5wuYY4oI7zSeIbZEhYoY1YqaWaYLmGJdiZl2Z-nI0tYIa2wsZX6xc_bh83EIYHadrV2ZfgK_ZgVcPsGBYy01N37SIfgLqcy9H9bOt92kI-dT0BffPt6bcy0vpuN0_tO15BX-ngO6Uk3b237Zw15Dx-QU5muOcVcKJVKwQXlCVxDrNK1xJRhgikPNxVDAp-3E_BacamwyjhhOBQoHb4BB-fKEQ?type=png){alt="Relative references on the `main` branch with 9 commits showing the commit hash and the reference relative to the `HEAD`"}
+```
 
 If you want to undo the _last_ commit then you can do this using `git reset HEAD~1`.
 

--- a/episodes/diverging_branches.md
+++ b/episodes/diverging_branches.md
@@ -31,14 +31,13 @@ As you and your collaborator(s) work on your repository you may find that change
 has been merged via a Pull Request, but the work to address the Square Root function hasn't and is in effect behind the
 `main` branch. The following is a representation of the current state, albeit from a single developer.
 
-<!-- Source for Mermaid diagram :
-     https://gist.github.com/ns-rse/08fb86b003a26f7855281eeea88566d0#file-git_graph_branching_diverging_branches-js
--->
-<!--
+``` mermaid
 %%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
          }
 }%%
     gitGraph
+       accTitle: Simple Git Branches
+       accDescr {Diverging branches in python-maths ns-rse/2-square-root is now behind the main branch which has incorporated the changes from ns-rse/1-zero-division.}
        commit id: "0-472f101"
        commit id: "1-51816d6"
        commit id: "2-6769ff2 (base)"
@@ -56,10 +55,7 @@ has been merged via a Pull Request, but the work to address the Square Root func
        merge "ns-rse/1-zero-division" id: "7-bc43901" tag: "Merge zero division"
        commit id: "HEAD"
 
--->
-
-<!-- markdownlint-disable-next-line MD013 -->
-![Diverging branches in `python-maths`: `ns-rse/2-square-root` is now behind the `main` branch which has incorporated the changes from `ns-rse/1-zero-division`.](https://mermaid.ink/img/pako:eNqtklFv2yAUhf8KQoq8SSYDbDD4bVqr9WF72tvkF4JxglqbDOOpreX_PkiaKpXadNJmP9j38N1zD9KdoXatgTVcrWY72FCDOQs705usBtlGjSbLQba14atX-12WTr0LKpgvru9t-KY25i6qwU9maQZweuL_slodhVPz87E-tALb1qCBGJUV7QgmDXwdIIgRQXjL3wIo4hWXXUfBh5T34xm38WrQu8gMI_Kj-UTQo_EOtfa3Ha0bLpAUjb8m5Q3yzoXzyTujb90U_sbzRcoCCc1oq81FszfHnluVSBhdCKn-Ry6GaEFYp_C_5-JIFqYSlX7Nqld2eFZ747fmQtQnwwptdFnItBsgqG2Svh86Ew7eu9nN9eerBsIcxmlxeht3fE5kAw_73cAEtcrfJoMlctO-jYt93drgPKzTSudQTcH9eBj0qT4yV1ZtvepP4l4NP52LZafuxmMN6xnewxqVAq8lq-KLZcmpECyHD7DmeM0xZfFqRMr4kUsOHw8WdI1piQvBSMEKLmW1_AHrjxWc?type=png){alt-text="Diverging branches in `python-maths` `ns-rse/2-square-root` is now behind the `main` branch which has incorporated the changes from `ns-rse/1-zero-division`."}
+```
 
 In this example the `main` branch now includes the commits `3-8c52dce` and `5-2315fa0` from the `ns-rse/1-zero-division`
 branch as well as the commit `7-bc43901` which was made when the `ns-rse/1-zero-division` branch was merged in. The
@@ -79,17 +75,43 @@ There are two approaches to solving this: merging (`git merge`)  and rebasing (`
 
 ### Merging
 
-<!-- markdownlint-disable-next-line MD013 -->
-![**Before** - diverged branches in `python-maths`: `ns-rse/2-square-root` is now behind the `main` branch which has incorporated the changes from `ns-rse/1-zero-division`.](https://mermaid.ink/img/pako:eNqtklFv2yAUhf8KQoq8SSYDbDD4bVqr9WF72tvkF4JxglqbDOOpreX_PkiaKpXadNJmP9j38N1zD9KdoXatgTVcrWY72FCDOQs705usBtlGjSbLQba14atX-12WTr0LKpgvru9t-KY25i6qwU9maQZweuL_slodhVPz87E-tALb1qCBGJUV7QgmDXwdIIgRQXjL3wIo4hWXXUfBh5T34xm38WrQu8gMI_Kj-UTQo_EOtfa3Ha0bLpAUjb8m5Q3yzoXzyTujb90U_sbzRcoCCc1oq81FszfHnluVSBhdCKn-Ry6GaEFYp_C_5-JIFqYSlX7Nqld2eFZ747fmQtQnwwptdFnItBsgqG2Svh86Ew7eu9nN9eerBsIcxmlxeht3fE5kAw_73cAEtcrfJoMlctO-jYt93drgPKzTSudQTcH9eBj0qT4yV1ZtvepP4l4NP52LZafuxmMN6xnewxqVAq8lq-KLZcmpECyHD7DmeM0xZfFqRMr4kUsOHw8WdI1piQvBSMEKLmW1_AHrjxWc?type=png){alt-text="**Before** - diverged branches in `python-maths` `ns-rse/2-square-root` is now behind the `main` branch which has incorporated the changes from `ns-rse/1-zero-division`."}
-
-<!-- Source for Mermaid diagram :
-     https://gist.github.com/ns-rse/08fb86b003a26f7855281eeea88566d0#file-git_graph_branching_merging-js
--->
-<!--
+``` mermaid
 %%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
          }
 }%%
     gitGraph
+       accTitle: Diverging Branches
+       accDescr {Before - diverged branches in python-maths. The branch ns-rse/2-square-root is now behind the main
+       branch which has incorporated the changes from the ns-rse/1-zero-division branch.}
+       commit id: "0-472f101"
+       commit id: "1-51816d6"
+       commit id: "2-6769ff2 (base)"
+       branch "ns-rse/1-zero-division"
+       branch "ns-rse/2-square-root"
+       checkout "ns-rse/1-zero-division"
+       commit id: "3-8c52dce"
+       checkout "ns-rse/2-square-root"
+       commit id: "4-8ec389a"
+       checkout "ns-rse/1-zero-division"
+       commit id: "5-2315fa0"
+       checkout "ns-rse/2-square-root"
+       commit id: "6-93e787c"
+       checkout main
+       merge "ns-rse/1-zero-division" id: "7-bc43901" tag: "v0.1.1"
+       commit id: "HEAD"
+       checkout "main"
+
+```
+
+``` mermaid
+%%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
+         }
+}%%
+    gitGraph
+       accTitle: Merging Diverged Branches
+       accDescr {After - main, which has already had the work in ns-rse/1-zero-division merged into it, is
+       merged into ns-rse/2-square-root. Development is completed on ns-rse/2-square-root and the feature merged
+       into main.}
        commit id: "0-472f101"
        commit id: "1-51816d6"
        commit id: "2-6769ff2 (base)"
@@ -113,10 +135,7 @@ There are two approaches to solving this: merging (`git merge`)  and rebasing (`
        checkout "main"
        merge "ns-rse/2-square-root" id: "11-a8c9932" tag: "v0.1.2"
 
--->
-
-<!-- markdownlint-disable-next-line MD013 -->
-![**After** - `main`, which has already had the work in `ns-rse/1-zero-division` merged into it, is merged into `ns-rse/2-square-root`. Development is completed on `ns-rse/2-square-root` and the feature merged into `main`.](https://mermaid.ink/img/pako:eNqtk8GOmzAQhl8FWYpoJUxtA8bmVnVX7aE99VZxMcYk1i44NWbVXcS715CyTaIkqtpywuN_vvk9mhmBNLUCBdhsRt1pVwRj6HaqVWERhJXoVRgF4Va7j1bsd-F8a40TTn0wbavdZ1GpRx91dlBT2QXr5_-nzeYQWJNfr-WSGui6CEqAYJqTBiNcgssCDDPMMK3pNQGBNKe8aUjwZvb79khXWdHJndd0PbS9eofhi7IG1vpJ99p0N5QE9t8HYRW0xrjjyjslH8zg_oR54jKBTGakluom7GrZY1QKmZIJ4-J_-MogSXDWCPTvvijkicpZLi-hWqG712ir7FbdsPoLmMNKpgmfZyNwYjuHnlCM46uz8un-_d1fvWM1tLhcyzMoGJKqYb_Lf1l0B9VlCxzKiiX8tJ8n84wgFipLZXLZ6Rn8rFVnD1iZ2FuVnCfkrFNkJoEIeIrn1n7Nx5lcgmXFSzALa2EfZtnkdcO-9rt9X2tnLCjmrY6AGJz5-tzJ9XzQ3GmxtaIFRSMeex_di-6bMSdnUIzgBygwyWOcEoSTDHHMEU8i8AwKwmjMckwYyThllLIpAi8LAcUMYR9KEfU5Wcbx9BO0WV5-?type=png){alt-text="**After** - `main`, which has already had the work in `ns-rse/1-zero-division` merged into it, is merged into `ns-rse/2-square-root`. Development is completed on `ns-rse/2-square-root` and the feature merged into `main`."}
+```
 
 The syntax of `git merge` is
 
@@ -256,17 +275,43 @@ branches they are no longer shown by name in the `git log --graph` output.
 Rebasing moves the point at which the branch diverged from its original position to another, in this case the `HEAD` of
 the `main` branch. You are changing the `base` commit, hence the name `git rebase`.
 
-<!-- markdownlint-disable-next-line MD013 -->
-![**Before** - diverged branches in `python-maths`: `ns-rse/2-square-root` is now behind the `main` branch which has incorporated the changes from `ns-rse/1-zero-division`.](https://mermaid.ink/img/pako:eNqtklFv2yAUhf8KQoq8SSYDbDD4bVqr9WF72tvkF4JxglqbDOOpreX_PkiaKpXadNJmP9j38N1zD9KdoXatgTVcrWY72FCDOQs705usBtlGjSbLQba14atX-12WTr0LKpgvru9t-KY25i6qwU9maQZweuL_slodhVPz87E-tALb1qCBGJUV7QgmDXwdIIgRQXjL3wIo4hWXXUfBh5T34xm38WrQu8gMI_Kj-UTQo_EOtfa3Ha0bLpAUjb8m5Q3yzoXzyTujb90U_sbzRcoCCc1oq81FszfHnluVSBhdCKn-Ry6GaEFYp_C_5-JIFqYSlX7Nqld2eFZ747fmQtQnwwptdFnItBsgqG2Svh86Ew7eu9nN9eerBsIcxmlxeht3fE5kAw_73cAEtcrfJoMlctO-jYt93drgPKzTSudQTcH9eBj0qT4yV1ZtvepP4l4NP52LZafuxmMN6xnewxqVAq8lq-KLZcmpECyHD7DmeM0xZfFqRMr4kUsOHw8WdI1piQvBSMEKLmW1_AHrjxWc?type=png){alt-text="**Before** - diverged branches in `python-maths` `ns-rse/2-square-root` is now behind the `main` branch which has incorporated the changes from `ns-rse/1-zero-division`."}
-
-<!-- Source for Mermaid diagram :
-     https://gist.github.com/ns-rse/08fb86b003a26f7855281eeea88566d0#file-git_graph_branching_rebase-js
--->
-<!--
+``` mermaid
 %%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
          }
 }%%
     gitGraph
+       accTitle: Diverged Branches
+       accDescr {Before - diverged branches in python-maths. The branch ns-rse/2-square-root is now behind the main
+       branch which has incorporated the changes from the ns-rse/1-zero-division branch.}
+       commit id: "0-472f101"
+       commit id: "1-51816d6"
+       commit id: "2-6769ff2 (base)"
+       branch "ns-rse/1-zero-division"
+       branch "ns-rse/2-square-root"
+       checkout "ns-rse/1-zero-division"
+       commit id: "3-8c52dce"
+       checkout "ns-rse/2-square-root"
+       commit id: "4-8ec389a"
+       checkout "ns-rse/1-zero-division"
+       commit id: "5-2315fa0"
+       checkout "ns-rse/2-square-root"
+       commit id: "6-93e787c"
+       checkout main
+       merge "ns-rse/1-zero-division" id: "7-bc43901" tag: "v0.1.1"
+       commit id: "HEAD"
+       checkout "main"
+
+
+```
+
+``` mermaid
+%%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
+         }
+}%%
+    gitGraph
+       accTitle: Rebasing
+       accDescr {After - rebase to bring the diverged branch up-to-date with main which includes
+       ns-rse/1-zero-division. Two more commits are made and ns-rse/2-square-root is then merged into main.}
        commit id: "0-472f101"
        commit id: "1-51816d6"
        commit id: "2-6769ff2 (base)"
@@ -288,10 +333,7 @@ the `main` branch. You are changing the `base` commit, hence the name `git rebas
        checkout "main"
        merge "ns-rse/2-square-root" id: "9-ba93020" tag: "v0.1.2"
 
--->
-
-<!-- markdownlint-disable-next-line MD013 -->
-![**After** - rebase to bring the diverged branch up-to-date with `main` which includes `ns-rse/1-zero-division`. Two more commits are made and `ns-rse/2-square-root` is then merged into `main`.](https://mermaid.ink/img/pako:eNqtk02PmzAQhv8KshTRSjH1Bxiba1v10lN7q7gYYxJrF5was-ou4r_XziYrdpVEK7Wc8DvvPB7PaGagbKtBBTab2QzGV8mc-r3udVolaSNHnW6TdGf8NycP-zRGnfXS68-2743_Lht9H1TvJr3UQ3L-wv-y2TwL5-SXsDqmJqatkhogmJekwwjX4LIBwwJzzFp2zUAgK5noOpJ8iPV-XPkaJwe1D55hhG7UnzB80s7C1jyY0dhhTdxrdWcn_y7v-nYKuSpIq_T_gBWQUFx0El2C9dIML2qv3U7f4J-AJWxUTkXsbuLlLkoPKMPZhW6fwj90bOKNHhI4_p6k09BZ628--qpz_eQccq0oF_LfUQwKqkteqmuGEqqGU_G6vWsDh1jqIlf0cjHHCYBrM3hT4wkpYCMFRQS9mQCJoHoAWxAwAdyGFZwjugbH9atBtLbS3UXjEnzToQ1797U13jpQxY3bAjl5-_NxUOfzs-eLkTsne1B18n4M6kEOv6x9dQbVDP6ACpMywzlBmBZIYIEE3YJHUBHOMl5iwkkhGGeML1vwdCSgjCMcpByxkFMUAi9_ARUBQVQ?type=png){alt-text="**After** - rebase to bring the diverged branch up-to-date with `main` which includes `ns-rse/1-zero-division`. Two more commits are made and `ns-rse/2-square-root` is then merged into `main`."}
+```
 
 `git rebase` takes a different approach to bringing branches up-to-date and in effect moves the point at which a branch
 diverged from `main` rather than merging the changes in.
@@ -416,12 +458,97 @@ In your pairs bring the `square-root` branch up-to-date and incorporate the chan
 The person who has been working on the `square-root` issue/branch will be at the helm for this, but work together to
 come up with a solution. You can use either of the two strategies `git merge` or `git rebase` to do this.
 
-<!-- markdownlint-disable-next-line MD013 -->
-![Diverged branches](https://mermaid.ink/img/pako:eNqtklFv2yAUhf8KQoq8SSYDbDD4bVqr9WF72tvkF4JxglqbDOOpreX_PkiaKpXadNJmP9j38N1zD9KdoXatgTVcrWY72FCDOQs705usBtlGjSbLQba14atX-12WTr0LKpgvru9t-KY25i6qwU9maQZweuL_slodhVPz87E-tALb1qCBGJUV7QgmDXwdIIgRQXjL3wIo4hWXXUfBh5T34xm38WrQu8gMI_Kj-UTQo_EOtfa3Ha0bLpAUjb8m5Q3yzoXzyTujb90U_sbzRcoCCc1oq81FszfHnluVSBhdCKn-Ry6GaEFYp_C_5-JIFqYSlX7Nqld2eFZ747fmQtQnwwptdFnItBsgqG2Svh86Ew7eu9nN9eerBsIcxmlxeht3fE5kAw_73cAEtcrfJoMlctO-jYt93drgPKzTSudQTcH9eBj0qT4yV1ZtvepP4l4NP52LZafuxmMN6xnewxqVAq8lq-KLZcmpECyHD7DmeM0xZfFqRMr4kUsOHw8WdI1piQvBSMEKLmW1_AHrjxWc?type=png){alt-text="Diverged branches"}
-<!-- markdownlint-disable-next-line MD013 -->
-![Merge](https://mermaid.ink/img/pako:eNqtk8GOmzAQhl8FWYpoJUxtA8bmVnVX7aE99VZxMcYk1i44NWbVXcS715CyTaIkqtpywuN_vvk9mhmBNLUCBdhsRt1pVwRj6HaqVWERhJXoVRgF4Va7j1bsd-F8a40TTn0wbavdZ1GpRx91dlBT2QXr5_-nzeYQWJNfr-WSGui6CEqAYJqTBiNcgssCDDPMMK3pNQGBNKe8aUjwZvb79khXWdHJndd0PbS9eofhi7IG1vpJ99p0N5QE9t8HYRW0xrjjyjslH8zg_oR54jKBTGakluom7GrZY1QKmZIJ4-J_-MogSXDWCPTvvijkicpZLi-hWqG712ir7FbdsPoLmMNKpgmfZyNwYjuHnlCM46uz8un-_d1fvWM1tLhcyzMoGJKqYb_Lf1l0B9VlCxzKiiX8tJ8n84wgFipLZXLZ6Rn8rFVnD1iZ2FuVnCfkrFNkJoEIeIrn1n7Nx5lcgmXFSzALa2EfZtnkdcO-9rt9X2tnLCjmrY6AGJz5-tzJ9XzQ3GmxtaIFRSMeex_di-6bMSdnUIzgBygwyWOcEoSTDHHMEU8i8AwKwmjMckwYyThllLIpAi8LAcUMYR9KEfU5Wcbx9BO0WV5-?type=png){alt-text="Merge"}
-<!-- markdownlint-disable-next-line MD013 -->
-![Rebase](https://mermaid.ink/img/pako:eNqtk02PmzAQhv8KshTRSjH1Bxiba1v10lN7q7gYYxJrF5was-ou4r_XziYrdpVEK7Wc8DvvPB7PaGagbKtBBTab2QzGV8mc-r3udVolaSNHnW6TdGf8NycP-zRGnfXS68-2743_Lht9H1TvJr3UQ3L-wv-y2TwL5-SXsDqmJqatkhogmJekwwjX4LIBwwJzzFp2zUAgK5noOpJ8iPV-XPkaJwe1D55hhG7UnzB80s7C1jyY0dhhTdxrdWcn_y7v-nYKuSpIq_T_gBWQUFx0El2C9dIML2qv3U7f4J-AJWxUTkXsbuLlLkoPKMPZhW6fwj90bOKNHhI4_p6k09BZ628--qpz_eQccq0oF_LfUQwKqkteqmuGEqqGU_G6vWsDh1jqIlf0cjHHCYBrM3hT4wkpYCMFRQS9mQCJoHoAWxAwAdyGFZwjugbH9atBtLbS3UXjEnzToQ1797U13jpQxY3bAjl5-_NxUOfzs-eLkTsne1B18n4M6kEOv6x9dQbVDP6ACpMywzlBmBZIYIEE3YJHUBHOMl5iwkkhGGeML1vwdCSgjCMcpByxkFMUAi9_ARUBQVQ?type=png){alt-text="Rebase"}
+``` mermaid
+%%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
+         }
+}%%
+    gitGraph
+       accTitle: Diverged Branches
+       accDescr {Diverged Branches.}
+       commit id: "0-472f101"
+       commit id: "1-51816d6"
+       commit id: "2-6769ff2 (base)"
+       branch "ns-rse/1-zero-division"
+       branch "ns-rse/2-square-root"
+       checkout "ns-rse/1-zero-division"
+       commit id: "3-8c52dce"
+       checkout "ns-rse/2-square-root"
+       commit id: "4-8ec389a"
+       checkout "ns-rse/1-zero-division"
+       commit id: "5-2315fa0"
+       checkout "ns-rse/2-square-root"
+       commit id: "6-93e787c"
+       checkout main
+       merge "ns-rse/1-zero-division" id: "7-bc43901" tag: "v0.1.1"
+       commit id: "HEAD"
+       checkout "main"
+
+
+```
+
+``` mermaid
+%%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
+         }
+}%%
+    gitGraph
+       accTitle: Merging Diverged Branches
+       accDescr {After - main, which has already had the work in ns-rse/1-zero-division merged into it, is
+       merged into ns-rse/2-square-root. Development is completed on ns-rse/2-square-root and the feature merged
+       into main.}
+       commit id: "0-472f101"
+       commit id: "1-51816d6"
+       commit id: "2-6769ff2 (base)"
+       branch "ns-rse/1-zero-division"
+       branch "ns-rse/2-square-root"
+       checkout "ns-rse/1-zero-division"
+       commit id: "3-8c52dce"
+       checkout "ns-rse/2-square-root"
+       commit id: "4-8ec389a"
+       checkout "ns-rse/1-zero-division"
+       commit id: "5-2315fa0"
+       checkout "ns-rse/2-square-root"
+       commit id: "6-93e787c"
+       checkout main
+       merge "ns-rse/1-zero-division" id: "7-bc43901" tag: "v0.1.1"
+       commit id: "HEAD"
+       checkout "ns-rse/2-square-root"
+       merge "main" id: "8-a80cef8" tag: "Merge main"
+       commit id: "9-cb839a0"
+       commit id: "10-1ae54c3"
+       checkout "main"
+       merge "ns-rse/2-square-root" id: "11-a8c9932" tag: "v0.1.2"
+
+```
+
+``` mermaid
+%%{init: {'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}
+         }
+}%%
+    gitGraph
+       accTitle: Rebase
+       accDescr {Rebase.}
+       commit id: "0-472f101"
+       commit id: "1-51816d6"
+       commit id: "2-6769ff2 (base)"
+       branch "ns-rse/1-zero-division"
+       checkout "ns-rse/1-zero-division"
+       commit id: "3-8c52dce"
+       checkout "ns-rse/1-zero-division"
+       commit id: "5-2315fa0"
+       checkout main
+       merge "ns-rse/1-zero-division" id: "7-bc43901" tag: "v0.1.1"
+       commit tag: "Rebase"
+       branch "ns-rse/2-square-root"
+       checkout "ns-rse/2-square-root"
+       commit id: "4-8ec389a"
+       checkout "ns-rse/2-square-root"
+       commit id: "6-93e787c"
+       commit id: "7-cb839a0"
+       commit id: "8-1ae54c3"
+       checkout "main"
+       merge "ns-rse/2-square-root" id: "9-ba93020" tag: "v0.1.2"
+
+```
 
 :::::::::::::::::::::::: solution
 

--- a/episodes/further_resources.md
+++ b/episodes/further_resources.md
@@ -107,6 +107,7 @@ Various tutorials and tools that help explain how Git works.
 - [Flight rules for git](https://github.com/k88hudson/git-flight-rules) an excellent clear set of resources of how to
   solve different problems/scenarios.
 - [The Git Parable](https://tom.preston-werner.com/2009/05/19/the-git-parable.html) a narrative of how Git works.
+- [Git Hug](https://github.com/Gazler/githug) a game that helps you learn Git.
 
 #### Git Configuration
 


### PR DESCRIPTION
Closes #172
Closes #168

Now Mermaid diagrams can be included directly in the Workbench thanks to an update to the Sandpaper package this
switches to using those so the code is now directly version controlled and not a commented section.

Also adds a link to the Git Hug game.