### PR TITLE
Revert setup instructions and tidy up venv ref

### DIFF
--- a/episodes/additional_topics.md
+++ b/episodes/additional_topics.md
@@ -322,9 +322,9 @@ worktree and add the `CITATION.cff`
 
 ```bash
 cd contributing
-echo -e "# Contributing\n\nContributions to this repository are welcome via Pull Requests." > CONTRIBUTING.md
+echo "# Contributing\n\nContributions to this repository are welcome via Pull Requests." > CONTRIBUTING.md
 cd ../citation
-echo -e "cff-version: 1.2.0\ntitle: Pytest Examples\ntype: software" > CITATION.cff
+echo "cff-version: 1.2.0\ntitle: Pytest Examples\ntype: software" > CITATION.cff
 ```
 
 Neither branches have had the changes committed so Git will not show any differences between them, but we can use `diff

--- a/episodes/branching.md
+++ b/episodes/branching.md
@@ -705,7 +705,7 @@ For a detailed exposition of `git reset` see the excellent [Atlassian | Git rese
 ## Challenge 7: Commits on the wrong branch
 
 - Switch to the `main` branch of the `pytest-maths` repository.
-- Create a new file using `echo -e "# This is TODO list" > TODO.md`
+- Create a new file using `echo "# This is TODO list" > TODO.md`
 - Stage and commit the file to the `main` branch of your repository. **NB** to do this you may have to disable the
   `pre-commit` checks with the `-n` flag, i.e. `git commit -n`.
 
@@ -725,7 +725,7 @@ commit history, leaving it unstaged, then create a new branch and add it to that
 
 ``` bash
 git switch main
-echo -e "# This is a TODO list" > TODO.md
+echo "# This is a TODO list" > TODO.md
 git add TODO.md
 git commit -n -m "docs: Adding a todo file"
 git reset --mixed HEAD~1
@@ -746,7 +746,7 @@ file and _then_ remove the commit from main.
 
 ``` bash
 git switch main
-echo -e "# This is a TODO list" > TODO.md
+echo "# This is a TODO list" > TODO.md
 git add TODO.md
 git commit -n -m "docs: Adding a todo file"
 git log              # Note the commit of the mistaken hash
@@ -846,10 +846,10 @@ But there is a challenge, in order to switch branches you have to stage and comm
 
 ``` bash
 git switch -c branch2
-echo -e "\nAny questions please feel free to get in touch\n" >> CONTRIBUTING.md
+echo "\nAny questions please feel free to get in touch\n" >> CONTRIBUTING.md
 git add CONTRIBUTING.md
 git commit -m "Adding CONTRIBUTING.md"
-echo -e "\nPlease don't break my repository though!" >> CONTRIBUTING.md
+echo "\nPlease don't break my repository though!" >> CONTRIBUTING.md
 git switch main
 
 error: Your local changes to the following files would be overwritten by checkout:
@@ -928,7 +928,7 @@ different message.
 ``` bash
 git switch -c example-stashes
 git stash --message "WIP CONTRIBUTING.md file"
-echo -e "Yet another file" > ANOTHER.md
+echo "Yet another file" > ANOTHER.md
 git add ANOTHER.md
 git stash --message "WIP ANOTHER.md file"
 
@@ -979,10 +979,10 @@ ANOTHER.md: No such file or directory (os error 2).
 Working in your pairs on the `python-maths` repository...
 
 1. Create a `<github-username>/todo` branch.
-2. Create a `TODO.md` with `echo -e "# This is a ToDo List\n\n1. Task1\n2. Task2." > TODO.md`
+2. Create a `TODO.md` with `echo "# This is a ToDo List\n\n1. Task1\n2. Task2." > TODO.md`
 3. Do _not_ add and commit, instead `git stash -m "WIP : adding TODO.md"` your changes
 4. Switch to the `main` branch and create a `<github-username>/citation` branch.
-5. Add a basic `CITATION.cff` with `echo -e "cff-version: 1.2.0\ntitle: Python Maths Package\ntype: software" > CITATION.cff`
+5. Add a basic `CITATION.cff` with `echo "cff-version: 1.2.0\ntitle: Python Maths Package\ntype: software" > CITATION.cff`
 6. Add and commit this file.
 7. Unstash the `TODO.md` file on the `citation` branch.
 8. Stage and commit the changes. Do **NOT** create a pull request or merge these changes.
@@ -999,7 +999,7 @@ Lets create the `<github-username>/todo` branch
 git switch main
 git pull
 git switch -c <github-username>/todo
-echo -e "# This is a ToDo List\n\n1. Task1\n2.Task2." > TODO.md
+echo "# This is a ToDo List\n\n1. Task1\n2.Task2." > TODO.md
 ```
 
 If we want to switch branches without making a commit but save our work in progress we stash the work and switch to
@@ -1009,7 +1009,7 @@ If we want to switch branches without making a commit but save our work in progr
 git stash -m "WIP : adding TODO.md"
 git switch main
 git switch -c <github-username>/citation
-echo -e "cff-version: 1.2.0\ntitle: Python Maths Package\ntype: software" > CITATION.cff
+echo "cff-version: 1.2.0\ntitle: Python Maths Package\ntype: software" > CITATION.cff
 git add CITATION.cff
 git commit -m "doc: Adding a CITATION.cff"
 ```

--- a/episodes/diverging_branches.md
+++ b/episodes/diverging_branches.md
@@ -174,7 +174,7 @@ git commit --allow-empty -m "Initial commit"
 
 ``` bash
 git switch -c branch1
-echo -e "# Just a test" > README.md
+echo "# Just a test" > README.md
 git add README.md
 git commit -m "docs: Adding README.md"
 git lol
@@ -195,7 +195,7 @@ git lol
 
 ``` bash
 git switch -c branch2
-echo -e "YOU CAN DO WHAT YOU WANT WITH THIS CODE" > LICENSE
+echo "YOU CAN DO WHAT YOU WANT WITH THIS CODE" > LICENSE
 git add LICENSE
 git commit -m "chore: Adding a LICENSE"
 git lol
@@ -373,7 +373,7 @@ git commit --allow-empty -m "Initial commit"
 
 ``` bash
 git switch -c branch1
-echo -e "# Just a test" > README.md
+echo "# Just a test" > README.md
 git add README.md
 git commit -m "docs: Adding README.md"
 ```
@@ -391,7 +391,7 @@ cat README.md   # Note that `README.md` does not currently exist on this branch
 
 ``` bash
 git switch -c branch2
-echo -e "YOU CAN DO WHAT YOU WANT WITH THIS CODE" > LICENSE
+echo "YOU CAN DO WHAT YOU WANT WITH THIS CODE" > LICENSE
 git add LICENSE
 git commit -m "docs: Adding a LICENSE"
 ```
@@ -680,10 +680,10 @@ Again we add a `README.md` but this time we make two commits to it, adding an ex
 
 ``` bash
 git switch -c branch1
-echo -e "# Just a test\n\n" > README.md
+echo "# Just a test\n\n" > README.md
 git add README.md
 git commit -m "docs: Adding README.md"
-echo -e "Lets add another line in a separate commit" >> README.md
+echo "Lets add another line in a separate commit" >> README.md
 git add README.md
 git commit -m "docs: Ooops, missed a line from the README.md"
 git lol
@@ -709,7 +709,7 @@ already exists on `branch1`. We put different text into it.
 
 ``` bash
 git switch -c branch2
-echo -e "# Just a test\n\nBut we're creating a merge conflict\n" > README.md
+echo "# Just a test\n\nBut we're creating a merge conflict\n" > README.md
 git add README.md
 git commit -m "This repo needs a README.md"
 cat README.md
@@ -739,7 +739,7 @@ two commits on this branch after the "Initial commit".
 ``` bash
 # Switch to branch2 add more to `README.md` and rebase
 git switch branch2
-echo -e "Lets add another commit to make things messier" >> README.md
+echo "Lets add another commit to make things messier" >> README.md
 git add README.md
 git commit -m "Bulking out README.md with more information"
 git lol

--- a/episodes/git_hygiene.md
+++ b/episodes/git_hygiene.md
@@ -6,18 +6,21 @@ exercises: 2
 
 :::::::::::::::::::::::::::::::::::::: questions
 
+- How do I configure Git globally and locally?
 - How do we keep our repository and history clean?
-- How do I avoid `Fixing typo` commits?
 - What are atomic commits?
+- How do I avoid `Fixing typo` commits?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::: objectives
 
+- Command line configuration of Git.
+- Manually editing Git configuration files.
+- Use `.gitignore` to avoid adding unnecessary files.
 - Understand the concept of Atomic commits.
 - Amending and fixing commits.
 - Squashing commits.
-- Rebasing commits interactively.
 - Staging hunks with `--patch`.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
@@ -57,7 +60,7 @@ We  will create a `CONTRIBUTING.md` to the repository, you can either copy and p
 can use `nano CONTRIBUTING.md` to add the file.
 
 ``` bash
-echo -e "# Contributing\n\nTo contribute please make a fork of this repository, make your changes and open a Pull Request." > CONTRIBUTING.md
+echo "# Contributing\n\nTo contribute please make a fork of this repository, make your changes and open a Pull Request." > CONTRIBUTING.md
 git add CONTRIBUTING.md
 git commit -m "docs: Ask for PRs via fork in CONTRIBUTING.md\n"
 ```
@@ -91,7 +94,7 @@ test suite and find that on running it your tests fail so you needed to make a c
 more explicit about how to report bugs.
 
 ``` bash
-echo -e "Bug reports are also welcome please create an [issue](https://github.com/<user-name>/python-maths/issues).\n" >> CONTRIBUTING.md
+echo "Bug reports are also welcome please create an [issue](https://github.com/<user-name>/python-maths/issues).\n" >> CONTRIBUTING.md
 ```
 
 We could add a new commit for this.
@@ -169,7 +172,7 @@ git lol
 Now let's expand our `CONTRIBUTING.md` file further.
 
 ``` bash
-echo -e "\nPlease note this repository uses [pre-commit](https://pre-commit.com) to lint the Python code and Markdown files." >> CONTRIBUTING.md
+echo "\nPlease note this repository uses [pre-commit](https://pre-commit.com) to lint the Python code and Markdown files." >> CONTRIBUTING.md
 ```
 
 We want to merge this commit with the first one we made in this tutorial and can do so using `git commit --fixup`. To do

--- a/episodes/hooks.md
+++ b/episodes/hooks.md
@@ -38,7 +38,7 @@ they are _not_ executed in response to any of the actions.
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: instructor
 
-Make sure the audience understands what the `commit`, `push` and `pull` events are and they they are actions for git to
+Make sure the audience understands what the `commit`, `push` and `pull` events are and they are actions for git to
 make on the repository at different stages in the Git workflow.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -231,7 +231,7 @@ exec git pull
 
 This section requires you to either install `pre-commit` at the system level or setup a Virtual Environment.
 
-Instructions on doing so can be found at the bottom of the [document](hooks.md#installing_pre-commit).
+Instructions on doing so can be found at the bottom of the [document](hooks.md#installing-pre-commit).
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -848,7 +848,7 @@ The `.pylintrc` file is a configuration file for `pylint` that defines what chec
 
 ::::::::::::::::::::::::::::::::::::: challenge
 
-## Challenge 9: Define local `pre-commit` repo to run a `pytest` hook
+## Challenge 7: Define local `pre-commit` repo to run a `pytest` hook
 
 The `python-maths` repository has a suite of tests that can be run to ensure the code works as expected.
 
@@ -954,10 +954,18 @@ the
 
 ## Installing Pre-commit
 
+On Linux systems or OSX OS's you can install [pre-commit][pc] at the system level. The advantage of this is that you
+will be able to `pre-commit install` in any repository without first having to activate a virtual environment.
+
 ### Install Pre-commit globally
 
-Examples of installing [pre-commit][pc] at the system level for different Linux systems or OSX. Note you will
-need to have `root` access to install packages on your Linux system.
+::::::::::::::::::::::::::::::::::::: challenge
+
+:::::::::::::::::::::::: solution
+
+## GNU/Linux
+
+Note you will need to have `root` access to install packages on your Linux system.
 
 ``` bash
 # Arch Linux
@@ -970,8 +978,22 @@ apt-get install pre-commit
 brew install pre-commit
 ```
 
-The advantage of this is that you will be able to `pre-commit install` in any repository without first having to
-activate a virtual environment.
+:::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::: solution
+
+## OSX
+
+If you use the [homebrew][homebrew] package manager for OSX you can install `pre-commit` with the following.
+
+``` bash
+# OSX Homebrew
+brew install pre-commit
+```
+
+:::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::::::::::::::
 
 ### Virtual Environments
 
@@ -993,7 +1015,11 @@ for virtual environments (e.g. [uv][uv], [miniforge3][miniforge3] or [virtualenv
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-### Installing Miniconda/Miniforge3
+::::::::::::::::::::::::::::::::::::: challenge
+
+:::::::::::::::::::::::: solution
+
+## Installing Miniconda/Miniforge3
 
 Please follow the instructions at [Installing Miniconda](https://docs.anaconda.com/free/miniconda/miniconda-install/)
 for your Operating System.
@@ -1001,15 +1027,25 @@ for your Operating System.
 Should you chose to use `miniforge3` the downloads and installation instructions for different operating systems can be
 found on their [install instructions][miniforge3-install].
 
-### Creating A Virtual Environment
+:::::::::::::::::::::::::::::::::
 
-You will have to create a virtual environment to undertake the course. If you have installed Miniconda as described
-above you open a terminal (Windows use the Git Bash Shell) and create a Virtual Environment called `git-collaboation`.
+:::::::::::::::::::::::: solution
+
+## Creating A Virtual Environment with pre-commit
+
+Once installed you will have to create a virtual environment and install both Python and [pre-commit][pc]. If you have
+installed Miniconda as described above you open a terminal (Windows use the Git Bash Shell) and create a Virtual
+Environment called `git-collaboation`.
 
 ``` bash
-conda create --name git-collab python=3.11
-conda activate git-collab
+conda create --name python-maths python=3.13 pre-commit
+conda activate python-maths
+which {python,pre-commit}
 ```
+
+:::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::::::::::::::
 
 [anacondalicense]: https://www.anaconda.com/blog/update-on-anacondas-terms-of-service-for-academia-and-research
 [bash]: https://www.gnu.org/software/bash/
@@ -1017,6 +1053,7 @@ conda activate git-collab
 [gh]: https://github.com
 [gl]: https://gitlab.com
 [grep]: https://en.wikipedia.org/wiki/Grep
+[homebrew]: https://brew.sh
 [miniconda3]: https://docs.anaconda.com/free/miniconda/
 [miniforge3]: https://conda-forge.org/
 [miniforge3-install]: https://github.com/conda-forge/miniforge

--- a/episodes/introduction.md
+++ b/episodes/introduction.md
@@ -663,62 +663,6 @@ The **Collaborator** should receive an email invitation to collaborate and shoul
 
 :::::::::::::::::::::::::::::::::
 
-:::::::::::::::::::::::: solution
-
-## Install the Package (**Both**)
-
-**NB** Both the **Repository Owner**, the **Collaborator** should perform this step.
-
-If you have not already done so activate the `git-with-it` environment you created as described in the setup
-instructions.
-
-``` bash
-conda activate git-with-it
-```
-
-You can now install the package and its test dependencies in an editable format so that as you work on the package the
-changes you make will instantly be available. Make sure you are in the `python-maths` directory (use `pwd` to show where
-you are and `cd` to change directory).
-
-``` bash
-pwd
-cd ~/work/git/python-maths
-pip install -e .[tests,dev]
-```
-
-You can optionally check everything is installed and runs by running the tests via [pytest][pytest].
-
-``` bash
-pytest
-========================================== test session starts ==========================================
-platform linux -- Python 3.13.1, pytest-8.3.4, pluggy-1.5.0
-Matplotlib: 3.10.0
-Freetype: 2.6.1
-rootdir: /home/neil/tmp/gitcollab-20250210/python-maths
-configfile: pyproject.toml
-testpaths: tests
-plugins: cov-6.0.0, github-actions-annotate-failures-0.3.0, mpl-0.17.0
-collected 25 items
-
-tests/test_arithmetic.py .....................                                                                                                           [ 84%]
-tests/test_trig.py ....                                                                                                                                  [100%]
-
----------- coverage: platform linux, python 3.13.1-final-0 -----------
-Name                        Stmts   Miss  Cover
------------------------------------------------
-pythonmaths/arithmetic.py       8      0   100%
-pythonmaths/trig.py             4      0   100%
------------------------------------------------
-TOTAL                          12      0   100%
-
-
-========================================== 25 passed in 0.28s ===========================================
-```
-
-:::::::::::::::::::::::::::::::::
-
-After completing these steps you should both have a copy of the `python-maths` repository on your local computer.
-
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::: callout
@@ -766,7 +710,6 @@ share and update changes to the code base (although they are [mirrored on GitHub
 [pairprogramming]: https://en.wikipedia.org/wiki/Pair_programming
 [pypi]: https://pypi.org/
 [pythonMaths]: https://github.com/FAIR2-for-research-software/python-maths
-[pytest]: https://docs.pytest.org/
 [rustGithub]: https://github.com/rust-lang/rust
 [r]: https://www.r-project.org/
 [readline]: https://tiswww.cwru.edu/php/chet/readline/rltop.html

--- a/episodes/introduction.md
+++ b/episodes/introduction.md
@@ -278,7 +278,7 @@ You may want to set the following alias in your `~/.bashrc` file, it sets variou
 ~/.bashrc` to
 
 ```bash
-echo -e "export alias nano='nano --linenumbers'" >> ~/.bashrc
+echo "alias nano='nano --autoindent --linenumbers --tabstospaces --tabsize=4'" >> ~/.bashrc
 
 ```
 
@@ -308,19 +308,16 @@ Each repository that is under Git version control has a `.git/` directory where 
 history live. Within this directory you will find a `.git/config` file which is the "local" configuration for that
 repository. **Configuration options defined locally over-ride global configuration options**.
 
-### Modifying Configuration
-
 There are two ways of modifying either the global or local configuration, using the Command Line `git config <options>`
-or by editing either the global (`~/.gitconfig`) or local (`.git/config`) files.
+or by editing either the global (`~/.gitconfig`) or local (`git/config`) files.
 
-#### `git config`
+### `git config`
 
 The `git config` command has a host of options that you can view with the `--help` flag. The first required option says
 what file should be modified and is typically either `global` or `local`. You can view the configuration with `git
 config --list` and you can optionally restrict it to show either the `--global` or `--local` configuration.
 
 ``` bash
-cd ~/path/to/cloned/python-maths
 git config --list
 git config --list --local
 git config --list --global
@@ -331,14 +328,14 @@ shown below.
 
 ``` bash
 [user]
-  email = a.n.other@sheffield.ac.uk
-  name = A N Other
+ email = a.n.other@sheffield.ac.uk
+ name = A N Other
 [core]
-  editor = nano
-  sshCommand = ssh -i ~/.ssh/id_ed25519 -F /dev/null
-  attributesFile = $HOME/.gitattributes
-  autocrlf = input
-  excludesFile = ~/.config/git/.gitignore
+ editor = nano
+ sshCommand = ssh -i ~/.ssh/id_ed25519 -F /dev/null
+ attributesFile = $HOME/.gitattributes
+ autocrlf = input
+ excludesFile = ~/.config/git/.gitignore
 ```
 
 Sections are in square brackets with names, e.g. `[user]` or `[core]`. Fields then have key and value pairs e.g. the
@@ -401,7 +398,7 @@ git config --global core.editor nano
 
 ## Solution 2 - Editing `~/.gitconfig`
 
-You could alternatively edit the `~/.gitconfig` (or `~/.config/git/config`) file directly and add the following lines.
+You could alternatively edit the `~/.gitconfig` file directly and add the following lines
 
 ``` bash
 [core]
@@ -472,7 +469,26 @@ git config --global alias.lol 'log --graph --pretty=format:"%C(yellow)%h\\ %C(gr
 :::::::::::::::::::::::::::::::::
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-## `.gitignore`
+::::::::::::::::::::::::::::::::::::: callout
+
+## Useful `git fire` alias
+
+You may have seen the common Git meme about committing and pushing your changes before exiting the building if there is
+a fire alarm...
+
+![In case of fire... `git commit`, `git
+push`](https://cknoll.github.io/images/2025-09-git-fire/git-gommit-push-leave-building.png)
+
+Whilst humorous its not the best advice as there are [problems][git_commit_problems] with this approach. You can
+however, as noted in the linked blog, set an alias for this which makes it quick and easy to save your changes.
+
+``` bash
+git config --global alias.fire '!git switch -c emergency-backup && git commit -a -m "emergency commit" && git push -u origin emergency-backup'
+```
+
+::::::::::::::::::::::::::::::::::::::::::::::::
+
+### `.gitignore`
 
 The [`.gitignore`][gitignore] file does exactly what you might expect it to, it contains lists of directories and files
 that should be ignored by Git. To save having to write out the path to each and every file the format accepts
@@ -489,7 +505,7 @@ Python pickles. Thus to exclude all `.csv` files you would add...
 *.csv
 ```
 
-Just as you can exclude files you can also ignore directories and a common one you may wish to ignore is the `.DS_Store/`
+Just as you can exclude files you can also ignore directories and a common one you may wish to ignore is the `.DS_Store`
 directory that Mac OSX automatically generates in most directories. The ignore pattern for that includes a trailing
 slash.
 
@@ -736,6 +752,8 @@ share and update changes to the code base (although they are [mirrored on GitHub
 [gitaliases]: https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases
 [gitignore]: https://git-scm.com/docs/gitignore
 [gitignorepatterns]: https://git-scm.com/docs/gitignore#_pattern_format
+[git_commit_problems]: https://cknoll.github.io/git-fire-en.html
+[git_includeif]: https://blog.nshephard.dev/posts/git-ssh/#conditional-includes
 [gh]: https://github.com
 [gh_newrepo]: https://github.com/new
 [gl]: https://gitlab.com

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -4,7 +4,7 @@ title: Setup
 
 ## Git
 
-There are many [Git][git] clients (porcelains) out there and many Integrated Development Environments (IDEs) support Git
+There are many Git clients (porcelains) out there and many Integrated Development Environments (IDEs) support Git
 actions and facilitate using the bewildering array of options, but this course teaches the Command Line Interface (CLI)
 to Git as it means we have a consistent interface to teach the _principles_ that you can take away to your own choice of
 Git client. Below there are instructions for installing Git on each of the three most common operating systems.
@@ -12,14 +12,24 @@ Git client. Below there are instructions for installing Git on each of the three
 Please complete these setup tasks **before** attending the course. If you have any issues getting setup please either
 contact an instructor in advance or arrive early and seek assistance from an instructor.
 
-## Miniforge/Conda
+<!-- ## Example Repository -->
 
-We use the [Miniforge][miniforge]  virtual environment management system to install virtual
-environments and Git as it provides a consistent experience across operating systems.
+<!-- This course uses a GitHub Template that you will, in small groups, create a copy of and collaborate on. Using -->
+<!-- this template and setting it up is part of the course, you do not need to set it up in advance. -->
 
 ::::::::::::::::::::::::::::::::::::::: discussion
 
-Follow the [install instructions][miniforge_install] for your operating system to install Miniforge.
+## Install Git
+
+As this is a course about using [Git][git] you will need to have it installed on your computer. If you're already using
+Git then the chances are high you already have it installed or it may be integrated into your Integrated Development
+Environment (IDE).
+
+For consistency across operating systems this course uses the Command Line Interface (CLI) to Git and instructions below
+will guide you through installation on different Operating Systems. The principles can be applied to any Git Porcelain
+(client) that you choose (e.g. [GitKraken][gitkraken]), including IDEs such as [VSCode][vscode], PyCharm,
+[RStudio][rstudio] and [Emacs][emacs], although not all will support all of the functions introduced here (e.g. the
+RStudio Git interface is very basic).
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -27,106 +37,65 @@ Follow the [install instructions][miniforge_install] for your operating system t
 
 ### Windows
 
-> Download and execute the Windows installer. Follow the prompts, taking note of the option to "Create start menu
-> shortcuts". The most convenient and tested way to use the installed software (such as commands `conda` and `mamba`) is
-> via the "Miniforge Prompt" installed to the start menu.
-
-Once installed you should find the _Miniforge Prompt_ in your Start menu.
+You can use the [official binary][gitWin] but we encourage you to use [Git for Windows][git4windows] which includes the
+Bash shell and there are excellent
+[instructions](https://carpentries.github.io/workshop-template/install_instructions/#shell) on how to install this on
+the Carpentries installation instructions for the Bash Shell (**NB** the Git instructions for Windows on this page
+direct the reader to the Bash Shell instructions as they are bundled together).
 
 :::::::::::::::::::::::::
 
 :::::::::::::::: solution
 
-### Unix-like (Linux, MacOS, WSL)
+### MacOS
+
+[Git][git] is not included in the MacOS distribution by default. The [official instructions][gitMac] suggests using
+either [Homebrew](https://brew.sh/), [MacPorts](https://www.macports.org/) or
+[Xcode](https://developer.apple.com/xcode/).
+
+#### Homebrew
 
 ``` bash
-curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+brew install git
 ```
+
+#### MacPorts
 
 ``` bash
-wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+sudo port install git
 ```
-
-Then...
-
-``` bash
-bash Miniforge3-$(uname)-$(uname -m).sh
-```
-
-Answer the prompts for selecting an installation location. At the end of the installation you will see the following
-output and question...
-
-``` bash
-installation finished.
-Do you wish to update your shell profile to automatically initialize conda?
-This will activate conda on startup and change the command prompt when activated.
-If you'd prefer that conda's base environment not be activated on startup,
-   run the following command when conda is activated:
-
-conda config --set auto_activate_base false
-
-Note: You can undo this later by running `conda init --reverse $SHELL`
-
-Proceed with initialization? [yes|no]
-[no] >>> yes
-```
-
-Answer `yes` as it ensures that the `conda` base environment is activated each time you create
 
 :::::::::::::::::::::::::
 
-::::::::::::::::::::::::::::::::::::: callout
+### Linux
 
-### Unable to activate environment
+Most GNU/Linux distributions will have Git installed by default. If not you can install it using the package manager for
+your distribution. This will vary between distributions but some common ones are shown below. They assume you have
+`root` (administrator) access to your system via `sudo`. If `sudo` is not configured but you have `root` access then
+`su` and remove the `sudo` prefix from the following commands.
 
-If you are prompted to run `conda init` before `conda activate` and find this doesn't work then its possible a key step
-was missed out, most likely answering `yes` to have your shell profile updated mentioned above. To rectify this the
-following might help...
+#### Arch
 
 ``` bash
-source activate base
+sudo pacman -Syu git
 ```
 
-::::::::::::::::::::::::::::::::::::::::::::::::
-
-## Create a Virtual Environment
-
-We now need to create a virtual environment and install Python, Git and OpenSSH within it.
-
-::::::::::::::::::::::::::::::::::::::: discussion
-
-You should now create a virtual environment for the course and install Git and OpenSSH from the Conda-Forge channel.
-
-:::::::::::::::::::::::::::::::::::::::::::::::::::
-
-:::::::::::::::: solution
+#### Debian/Ubuntu
 
 ``` bash
-conda create --name git-with-it --channel conda-forge python git openssh
+sudo apt-get install git
 ```
 
-As the prompt suggests activate the environment...
+#### Fedora
 
 ``` bash
-conda activate git-with-it
+sudo dnf install git
 ```
 
-Check these are installed using the following commands
+#### Gentoo
 
 ``` bash
-which {git,ssh,ssh-keygen}
-```
-
-This will print out the path to each of the programmes `git`, `ssh` and `ssh-keygen`, the first part of the path will
-depend on _your_ computer, but  the last part of the output of each should  `miniforge/bin/git`, `miniforge/bin/ssh` and
-`miniforge/bin/ssh-keygen` respectively. An example is shown below.
-
-``` bash
- which {git,python,ssh,ssh-keygen}
-/home/neil/miniforge3/bin/git
-/home/neil/miniforge3/bin/python
-/home/neil/miniforge3/bin/ssh
-/home/neil/miniforge3/bin/ssh-keygen
+sudo emerge -av dev-vcs/git
 ```
 
 :::::::::::::::::::::::::
@@ -137,7 +106,7 @@ You will also need an account on [GitHub][gh]. If you do not already have one pl
 [register](https://github.com/signup), if you have an academic email address such as `@<institute>.ac.uk` or
 `@<institute.edu>` then registering with this address will give you access to a few more features.
 
-### SSH Keys
+## SSH Keys
 
 ::::::::::::::::::::::::::::::::::::::: discussion
 
@@ -152,12 +121,11 @@ account][github_ssh].
 
 ### Generate SSH Keys
 
-There is a detailed [article][ssh-keygen] on creating SSH keys under Linux and OSX that works with Git installed under
-the Conda/Miniforge install you should have made following the above instructions.
-It is recommended to use the newer [ed25519][ssh-ed25519] algorithm. In a terminal or Git Bash shell, you can do this
-using the following commands. You will be prompted to enter your password twice, **make sure to enter a secure
-(i.e. long) password, password-less keys are insecure!** and make sure you remember what the password is (**Hint** use a
-password manager!).
+There is a detailed [article][ssh-keygen] on creating SSH keys under Linux and OSX that works with Git Bash too. It is
+recommended to use the newer [ed25519][ssh-ed25519] algorithm. In a terminal or Git Bash shell, you can do this using
+the following commands. You will be prompted to enter your password twice, **make sure to enter a secure (i.e. long)
+password, password-less keys are insecure!**, make sure you remember what the password is (**Hint** use a password
+manager!).
 
 ```bash
 ssh-keygen -a 100 -t ed25519
@@ -172,9 +140,9 @@ default which will be `~/.ssh/id_ed25519`) and _then_ enter a secure passphrase 
 confirm you know what it is, do not forget it!).
 
 This creates two files in the `~/.ssh/` directory by default, the private key (`~/.ssh/id_ed25519'`) and the public key
-(`~/.ssh/id_ed25519.pub`). These are text files and it is the contents of the later with the `.pub` extension that you
-need to add to GitHub (see next solution). You can view the contents of the `~/.ssh/id_ed25519.pub` file that you need
-to copy to your GitHub account with.
+(`~/.ssh/id_ed25519.pub`). These are text files and it is the contents of the later that you need to add to GitHub (see
+next solution). You can view the contents of the `~/.ssh/id_ed25519.pub` file that you need to copy to your GitHub
+account with.
 
 ```bash
 cat ~/.ssh/id_ed25519.pub
@@ -207,53 +175,25 @@ Hi ns-rse! You've successfully authenticated, but GitHub does not provide shell 
 If you do **not** see the above successful authentication message please get in touch **before** the course starts.
 :::::::::::::::::::::::::
 
-## Clone a repository
-
-To undertake the work in this course you need to have a Git repository to work on. We will use the
-[python-maths][python-maths] repository for this.
-
-::::::::::::::::::::::::::::::::::::::: discussion
-
-### Cloning `python-maths`
-
-You should clone the [python-maths][python-maths] repository _before_ joining the first training session to the computer
-you will be using to undertake the work. As you have now setup SSH keys under your GitHub account you can
-
-- Navigate to [python-maths][python-maths] (use `Ctrl+click` to open in a new tab).
-- Click on the green Code button.
-- On the Local tab select SSH
-- Use the Copy button to the right of `git@github.com:FAIR2-for-research-software/python-maths.git` to copy  the SSH
-  URL.
-
-:::::::::::::::::::::::::::::::::::::::::::::::::::
-
-:::::::::::::::: solution
-
-You can clone the repository with the following...
-
-``` bash
-git clone git@github.com:FAIR2-for-research-software/python-maths
-```
-
-:::::::::::::::::::::::::
-
 ::::::::::::::::::::::::::::::::::::: keypoints
 
-Prior to attending the course you should have...
-
-- Installed Miniforge on your computer.
-- Created a virtual environment called `git-with-it` and included both `git` and `openssh` in this environment.
-- Created an SSH key and uploaded the public component to your GitHub Account (_Settings > SSH and GPG
+- You should have Git installed on your computer and opening a Terminal (or Git Bash Shell on Windows) you should be
+  able to type `git` and receive a summary of available commands.
+- You should have setup a GitHub account.
+- You should have created an SSH key and uploaded the public component to your GitHub Account (_Settings > SSH and GPG
   Keys_).
-- Cloned the [python-maths][python-maths] repository.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
+[emacs]: https://www.gnu.org/software/emacs/
 [gh]: https://github.com
 [git]: https://git-scm.com/
 [github_ssh]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
-[miniforge]: https://github.com/conda-forge/miniforge
-[miniforge_install]: https://github.com/conda-forge/miniforge?tab=readme-ov-file#install
-[python-maths]: https://github.com/FAIR2-for-research-software/python-maths
+[gitkraken]: https://www.gitkraken.com/
+[gitMac]: https://git-scm.com/download/mac
+[gitWin]: https://git-scm.com/download/win
+[git4windows]: https://carpentries.github.io/workshop-template/install_instructions/#shell
+[rstudio]: https://posit.co/download/rstudio-desktop/
 [ssh-ed25519]: https://blog.g3rt.nl/upgrade-your-ssh-keys.html
 [ssh-keygen]: https://www.digitalocean.com/community/tutorials/how-to-create-ssh-keys-with-openssh-on-macos-or-linux
+[vscode]: https://code.visualstudio.com/

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -67,6 +67,8 @@ sudo port install git
 
 :::::::::::::::::::::::::
 
+:::::::::::::::: solution
+
 ### Linux
 
 Most GNU/Linux distributions will have Git installed by default. If not you can install it using the package manager for


### PR DESCRIPTION
- Reverts the reworking of setup instructions to the original (Git, GitHub and SSH keys).
- Removes reference to Conda virtual environment from challenge at end of introduction
- Tidies up installing Conda environment instructions in Hooks episode and installs both Python and pre-commit when
  creating a virtual environment for the task.